### PR TITLE
feat: add optional Docker installation

### DIFF
--- a/Installer Scripts/Core/ct_build_functions.sh
+++ b/Installer Scripts/Core/ct_build_functions.sh
@@ -2,7 +2,7 @@
 
 # Author: Niicholai Black
 # Date: 6/6/2025
-# Version: 0.2.2 - Updated 6/10/2025
+# Version: 0.3.0 - Updated 6/10/2025
 # License: AGPL-3.0 - https://github.com/niicholai/Proxmox-Magic-Scripts?tab=AGPL-3.0-1-ov-file#readme
 # Inspired by: tteckster
 # Rest in peace tteck - you helped a lot of people find an easier way to get into self-hosting, including myself.
@@ -57,4 +57,38 @@ function update_container() {
   pct exec "$CTID" -- apt-get -y upgrade
 
   echo "SUCCESS: Container packages are up to date."
+}
+
+
+# --- Function to install Docker and Docker Compose ---
+function install_docker() {
+  echo "INFO: Installing Docker and Docker Compose..."
+
+  pct exec "$CTID" -- bash -s << 'EOF'
+# Abort the script if it fails
+set -e
+
+# --- Set up Docker's apt repo ---
+apt-get update
+apt-get install -y ca-certificates curl gnupg
+
+# Add Docker's official GPG key
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repo to Apt resources
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  bookworm stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# --- Install Docker Engine ---
+apt-get update
+
+# Install the latest versions of Docker Engine, CLI, containerd, and plugins
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+EOF
+
+  echo "SUCCESS: Docker and Docker Compose installed."
 }

--- a/Installer Scripts/Operating Systems/Debian/create_debian_ct.sh
+++ b/Installer Scripts/Operating Systems/Debian/create_debian_ct.sh
@@ -2,7 +2,7 @@
 
 # Author: Niicholai Black
 # Date: 6/8/2025
-# Version: 0.2.2 - Updated 6/10/2025
+# Version: 0.3.0 - Updated 6/10/2025
 # License: AGPL-3.0 - https://github.com/niicholai/Proxmox-Magic-Scripts?tab=AGPL-3.0-1-ov-file#readme
 # Inspired by: tteckster
 # Rest in peace tteck - you helped a lot of people find an easier way to get into self-hosting, including myself.
@@ -93,6 +93,7 @@ function run_setup() {
   done
 
   read -r -p "Enter MAC Address (optional): " MAC
+  read -r -p "Will you be using Docker? [y/N]: " INSTALL_DOCKER
 
   # --- Network Configuration ---
   local net_config="name=eth0,bridge=$BRIDGE,ip=dhcp"
@@ -106,6 +107,11 @@ function run_setup() {
   create_container
   start_container
   update_container
+
+  # --- Check if Docker installation is required and install it ---
+  if [[ "$INSTALL_DOCKER" == "y" || "$INSTALL_DOCKER" == "Y" ]]; then
+    install_docker
+  fi
 }
 
 


### PR DESCRIPTION
Adds a "Will you be using Docker?" prompt to the setup process to streamline the creation of Docker-ready containers.

If the user answers 'yes', the script automatically installs Docker Engine and the Docker Compose plugin inside the new container.

This implementation uses the official Docker `apt` repository method for Debian Bookworm, which is more secure and production-ready than using the convenience script. The installation logic is encapsulated in a new `install_docker` function in the function library.